### PR TITLE
Fix build with Rust v1.63 (MSRV)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,13 +7,13 @@ jobs:
     strategy:
       matrix:
         platform: [ ubuntu-latest, macos-latest, windows-latest ]
-        toolchain: [ stable, 1.63.0 ]
+        toolchain: [ stable, 1.64.0 ]
         include:
           - toolchain: stable
             check-fmt: true
         exclude:
           - platform: macos-latest
-            toolchain: 1.63.0
+            toolchain: 1.64.0
           - platform: windows-latest
             toolchain: stable
     runs-on: ${{ matrix.platform }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,11 +11,12 @@ jobs:
         include:
           - toolchain: stable
             check-fmt: true
+          - platform: ubuntu-latest
         exclude:
           - platform: macos-latest
             toolchain: 1.64.0
           - platform: windows-latest
-            toolchain: stable
+            toolchain: 1.64.0
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Checkout source code

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,14 +14,14 @@ jobs:
         include:
           - toolchain: stable
             check-fmt: true
-          - platform: ubuntu-latest
+            platform: ubuntu-latest
           - toolchain: 1.63.0
             msrv: true
         exclude:
           - platform: macos-latest
             toolchain: 1.63.0
           - platform: windows-latest
-            toolchain: 1.63.0
+            toolchain: stable
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Checkout source code

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,11 +34,7 @@ jobs:
         if: matrix.msrv
         run: |
           cargo update -p hashlink --precise "0.8.2" --verbose # hashlink 0.8.3 requires hashbrown 0.14, requiring 1.64.0
-          cargo update -p proptest --precise "1.2.0" --verbose # proptest 1.3.0 requires rustc 1.64.0
           cargo update -p reqwest --precise "0.11.20" --verbose # reqwest 0.11.21 broke 1.63.0 MSRV
-          cargo update -p regex --precise "1.9.6" --verbose # regex 1.10.0 requires rustc 1.65.0
-          cargo update -p zstd-sys --precise "2.0.8+zstd.1.5.5" --verbose # zstd-sys 2.0.9+zstd.1.5.5 requires rustc 1.64.0
-          cargo update -p petgraph --precise "0.6.3" --verbose # petgraph v0.6.4, requires rustc 1.64 or newer
       - name: Build on Rust ${{ matrix.toolchain }}
         run: cargo build --verbose --color always
       - name: Check formatting

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,16 +7,21 @@ jobs:
     strategy:
       matrix:
         platform: [ ubuntu-latest, macos-latest, windows-latest ]
-        toolchain: [ stable, 1.64.0 ]
+        toolchain: [
+          stable,
+          1.63.0, # Ldk-node MSRV
+        ]
         include:
           - toolchain: stable
             check-fmt: true
           - platform: ubuntu-latest
+          - toolchain: 1.63.0
+            msrv: true
         exclude:
           - platform: macos-latest
-            toolchain: 1.64.0
+            toolchain: 1.63.0
           - platform: windows-latest
-            toolchain: 1.64.0
+            toolchain: 1.63.0
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Checkout source code
@@ -25,6 +30,15 @@ jobs:
         run: |
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile=minimal --default-toolchain ${{ matrix.toolchain }}
           rustup override set ${{ matrix.toolchain }}
+      - name: Pin packages to allow for MSRV
+        if: matrix.msrv
+        run: |
+          cargo update -p hashlink --precise "0.8.2" --verbose # hashlink 0.8.3 requires hashbrown 0.14, requiring 1.64.0
+          cargo update -p proptest --precise "1.2.0" --verbose # proptest 1.3.0 requires rustc 1.64.0
+          cargo update -p reqwest --precise "0.11.20" --verbose # reqwest 0.11.21 broke 1.63.0 MSRV
+          cargo update -p regex --precise "1.9.6" --verbose # regex 1.10.0 requires rustc 1.65.0
+          cargo update -p zstd-sys --precise "2.0.8+zstd.1.5.5" --verbose # zstd-sys 2.0.9+zstd.1.5.5 requires rustc 1.64.0
+          cargo update -p petgraph --precise "0.6.3" --verbose # petgraph v0.6.4, requires rustc 1.64 or newer
       - name: Build on Rust ${{ matrix.toolchain }}
         run: cargo build --verbose --color always
       - name: Check formatting

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -656,6 +656,7 @@ dependencies = [
  "hex",
  "ldk-node",
  "tokio",
+ "winapi",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,6 @@ hex = "0.4.3"
 ldk-node = "0.1.0"
 tokio = { version = "1", features = [ "io-util", "macros", "rt", "rt-multi-thread", "sync", "net", "time" ] }
 
+[target.'cfg(windows)'.dependencies]
+winapi = { version = "0.3", features = ["winbase"] }
+

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 Sample lightning node command-line app built on top of
 [Ldk Node](https://github.com/lightningdevkit/ldk-node)
 (similar to
-[ldk sample](https://github.com/lightningdevkit/ldk-sample)
+[ldk-sample](https://github.com/lightningdevkit/ldk-sample)
 ).
 
 


### PR DESCRIPTION
- Build with Rust 1.63 required pinning some dependency package version
- For windows build, winapi crate is needed